### PR TITLE
修复mac下使用liteavatar不能正常显示的问题

### DIFF
--- a/src/handlers/avatar/liteavatar/liteavatar_handler_context.py
+++ b/src/handlers/avatar/liteavatar/liteavatar_handler_context.py
@@ -51,7 +51,7 @@ class HandlerTts2FaceContext(HandlerContext):
         while self.loop_running:
             no_output = True
             # get audio
-            if self.lite_avatar_worker.audio_out_queue.qsize() > 0:
+            if not self.lite_avatar_worker.audio_out_queue.empty():
                 no_output = False
                 try:
                     audio_tensor = self.lite_avatar_worker.audio_out_queue.get_nowait()
@@ -62,7 +62,7 @@ class HandlerTts2FaceContext(HandlerContext):
                 except Exception:
                     pass
             # get video
-            if self.lite_avatar_worker.video_out_queue.qsize() > 0:
+            if not self.lite_avatar_worker.video_out_queue.empty():
                 no_output = False
                 try:
                     video_tensor = self.lite_avatar_worker.video_out_queue.get_nowait()


### PR DESCRIPTION
在mac下使用liteavatar数字人时，当前会出现数字人不显示，并且TTS不能正常输出语音，存在如下报错：

```
/OpenAvatarChat/src/handlers/avatar/liteavatar/liteavatar_handler_context.py", line 54, in _media_out_loop
    if self.lite_avatar_worker.audio_out_queue.qsize() > 0:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/zgqiu/.local/share/uv/python/cpython-3.11.11-macos-aarch64-none/lib/python3.11/multiprocessing/queues.py", line 126, in qsize
    return self._maxsize - self._sem._semlock._get_value()
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
NotImplementedError
```

搜索显示具体原因可能是因为：

```
在 macOS 系统上，由于其进程间通信机制的限制，qsize() 方法通常会抛出 NotImplementedError。这是 Python 标准库在特定平台上的一个已知限制。

解决这个问题的方法是避免使用 qsize() 方法，改用其他方式检查队列状态：
```


修改后可以正常显示数字人

修改前：
<img width="1678" height="1422" alt="微信图片_20250917182548_753_805" src="https://github.com/user-attachments/assets/4d642587-a4e4-427e-842e-c24b5ca61ade" />

修改后：
<img width="1788" height="1444" alt="微信图片_20250917191647_769_805" src="https://github.com/user-attachments/assets/c1816950-a43e-4f98-b2a6-90b5329a4fca" />




