### PR TITLE
Fix Docker build by installing openmm before uv run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ COPY $CONFIG_FILE /tmp/build_config.yaml
 RUN chmod +x $WORK_DIR/scripts/pre_config_install.sh && \
     $WORK_DIR/scripts/pre_config_install.sh --config /tmp/build_config.yaml
 
+# Install runtime dependency required by uv execution
+RUN uv pip install -U openmm
+
 # Install config dependencies
 RUN uv run install.py \
     --config /tmp/build_config.yaml \


### PR DESCRIPTION
### What this PR does
Fixes Docker build failure caused by `uv run` being executed before `openmm` is installed.

### Why this is needed
`uv` does not automatically install runtime dependencies.
`openmm` must be installed before invoking any `uv run` commands.

### Changes
- Install `openmm` prior to `uv run install.py` in Dockerfile

### Result
Docker build completes successfully without runtime errors.

Fixes #271
