### PR TITLE
Add Atlas Cloud OpenAI-compatible preset

### DIFF
--- a/config/chat_with_atlascloud_edge_tts.yaml
+++ b/config/chat_with_atlascloud_edge_tts.yaml
@@ -1,0 +1,50 @@
+default:
+  logger:
+    log_level: "INFO"
+  service:
+    host: "0.0.0.0"
+    port: 8282
+    cert_file: "ssl_certs/localhost.crt"
+    cert_key: "ssl_certs/localhost.key"
+  chat_engine:
+    model_root: "models"
+    concurrent_limit: 1
+    handler_search_path:
+      - "src/handlers"
+    handler_configs:
+      RtcClient:
+        module: client/rtc_client/client_handler_rtc
+        connection_ttl: 900
+      InterruptHandler:
+        module: logic/interrupt/interrupt_handler
+      SileroVad:
+        module: vad/silerovad/vad_handler_silero
+        speaking_threshold: 0.5
+        start_delay: 2048
+        end_delay: 5000
+        buffer_look_back: 5000
+        speech_padding: 512
+      SenseVoice:
+        enabled: True
+        module: asr/sensevoice/asr_handler_sensevoice
+        model_name: "iic/SenseVoiceSmall"
+      Edge_TTS:
+        enabled: True
+        module: tts/edgetts/tts_handler_edgetts
+        voice: "zh-CN-XiaoxiaoNeural"
+      LLMOpenAICompatible:
+        enabled: True
+        module: llm/openai_compatible/llm_handler_openai_compatible
+        model_name: "qwen/qwen3.5-flash"
+        enable_video_input: False
+        history_length: 20
+        system_prompt: "请你扮演一个 AI 助手，用简短的两三句对话来回答用户的问题，并在对话内容中加入合适的标点符号，不需要讨论标点符号相关的内容"
+        api_url: "https://api.atlascloud.ai/v1"
+        api_key_env: "ATLASCLOUD_API_KEY"
+      LiteAvatar:
+        module: avatar/liteavatar/avatar_handler_liteavatar
+        avatar_name: 20250408/sample_data
+        fps: 25
+        debug: false
+        enable_fast_mode: false
+        use_gpu: true

--- a/docs/en/reference/handlers/llm/openai-compatible.md
+++ b/docs/en/reference/handlers/llm/openai-compatible.md
@@ -9,7 +9,8 @@ LLMOpenAICompatible:
   model_name: "qwen-plus"
   system_prompt: "You are an AI digital human."
   api_url: 'https://dashscope.aliyuncs.com/compatible-mode/v1'
-  api_key: 'yourapikey'
+  api_key: 'yourapikey' # optional; falls back to api_key_env
+  api_key_env: "DASHSCOPE_API_KEY"
 ```
 
 | Parameter | Default | Description |
@@ -18,6 +19,7 @@ LLMOpenAICompatible:
 | LLMOpenAICompatible.system_prompt | | System prompt |
 | LLMOpenAICompatible.api_url | | API URL |
 | LLMOpenAICompatible.api_key | | API Key |
+| LLMOpenAICompatible.api_key_env | DASHSCOPE_API_KEY | Environment variable to read when `api_key` is not set |
 
 > [!TIP]
 > OpenAvatarChat reads `.env` from the working directory for environment variables.

--- a/docs/en/reference/preset-modes.md
+++ b/docs/en/reference/preset-modes.md
@@ -8,6 +8,7 @@ OpenAvatarChat organizes modules based on config files. The `config` directory p
 | chat_with_qwen_omni.yaml | Qwen-Omni | Qwen-Omni | Qwen-Omni | lite-avatar |
 | chat_with_openai_compatible.yaml | SenseVoice | API | CosyVoice | lite-avatar |
 | chat_with_openai_compatible_edge_tts.yaml | SenseVoice | API | edgetts | lite-avatar |
+| chat_with_atlascloud_edge_tts.yaml | SenseVoice | Atlas Cloud API | edgetts | lite-avatar |
 | chat_with_openai_compatible_bailian_cosyvoice.yaml | SenseVoice | API | API | lite-avatar |
 | chat_with_openai_compatible_bailian_cosyvoice_musetalk.yaml | SenseVoice | API | API | MuseTalk |
 | chat_with_openai_compatible_bailian_cosyvoice_flashhead.yaml | SenseVoice | API | API | FlashHead |

--- a/docs/reference/handlers/llm/openai-compatible.md
+++ b/docs/reference/handlers/llm/openai-compatible.md
@@ -9,7 +9,8 @@ LLMOpenAICompatible:
   model_name: "qwen-plus"
   system_prompt: "你是个AI对话数字人，你要用简短的对话来回答我的问题，并在合理的地方插入标点符号"
   api_url: 'https://dashscope.aliyuncs.com/compatible-mode/v1'
-  api_key: 'yourapikey' # default=os.getenv("DASHSCOPE_API_KEY")
+  api_key: 'yourapikey' # 可选；未设置时读取 api_key_env 指定的环境变量
+  api_key_env: "DASHSCOPE_API_KEY"
 ```
 
 | 参数 | 默认值 | 说明 |
@@ -18,6 +19,7 @@ LLMOpenAICompatible:
 | LLMOpenAICompatible.system_prompt | | 默认系统 prompt |
 | LLMOpenAICompatible.api_url | | 模型 API URL |
 | LLMOpenAICompatible.api_key | | 模型 API Key |
+| LLMOpenAICompatible.api_key_env | DASHSCOPE_API_KEY | 未直接配置 `api_key` 时读取的环境变量名 |
 
 > [!TIP]
 > 系统默认会获取项目当前目录下的 `.env` 文件用来获取环境变量。

--- a/docs/reference/preset-modes.md
+++ b/docs/reference/preset-modes.md
@@ -8,6 +8,7 @@ OpenAvatarChat 按照配置文件启动并组织各个模块。项目在 `config
 | chat_with_qwen_omni.yaml | Qwen-Omni | Qwen-Omni | Qwen-Omni | lite-avatar |
 | chat_with_openai_compatible.yaml | SenseVoice | API | CosyVoice | lite-avatar |
 | chat_with_openai_compatible_edge_tts.yaml | SenseVoice | API | edgetts | lite-avatar |
+| chat_with_atlascloud_edge_tts.yaml | SenseVoice | Atlas Cloud API | edgetts | lite-avatar |
 | chat_with_openai_compatible_bailian_cosyvoice.yaml | SenseVoice | API | API | lite-avatar |
 | chat_with_openai_compatible_bailian_cosyvoice_musetalk.yaml | SenseVoice | API | API | MuseTalk |
 | chat_with_openai_compatible_bailian_cosyvoice_flashhead.yaml | SenseVoice | API | API | FlashHead |

--- a/src/handlers/llm/openai_compatible/llm_handler_openai_compatible.py
+++ b/src/handlers/llm/openai_compatible/llm_handler_openai_compatible.py
@@ -24,7 +24,8 @@ from chat_engine.data_models.chat_stream_config import ChatStreamConfig
 class LLMConfig(HandlerBaseConfigModel, BaseModel):
     model_name: str = Field(default="qwen-plus")
     system_prompt: str = Field(default="请你扮演一个 AI 助手，用简短的对话来回答用户的问题，并在对话内容中加入合适的标点符号，不需要加入标点符号相关的内容")
-    api_key: str = Field(default=os.getenv("DASHSCOPE_API_KEY"))
+    api_key: str = Field(default=None)
+    api_key_env: str = Field(default="DASHSCOPE_API_KEY")
     api_url: str = Field(default=None)
     enable_video_input: bool = Field(default=False)
     history_length: int = Field(default=20)
@@ -51,6 +52,12 @@ class LLMContext(HandlerContext):
 class HandlerLLM(HandlerBase, ABC):
     def __init__(self):
         super().__init__()
+
+    @staticmethod
+    def resolve_api_key(config: LLMConfig) -> Optional[str]:
+        if config.api_key:
+            return config.api_key
+        return os.getenv(config.api_key_env)
 
     def get_handler_info(self) -> HandlerBaseInfo:
         return HandlerBaseInfo(
@@ -85,8 +92,12 @@ class HandlerLLM(HandlerBase, ABC):
 
     def load(self, engine_config: ChatEngineConfigModel, handler_config: Optional[BaseModel] = None):
         if isinstance(handler_config, LLMConfig):
-            if handler_config.api_key is None or len(handler_config.api_key) == 0:
-                error_message = 'api_key is required in config/xxx.yaml, when use handler_llm'
+            api_key = self.resolve_api_key(handler_config)
+            if api_key is None or len(api_key) == 0:
+                error_message = (
+                    f'api_key or {handler_config.api_key_env} is required '
+                    'in config/xxx.yaml, when use handler_llm'
+                )
                 logger.error(error_message)
                 raise ValueError(error_message)
 
@@ -96,7 +107,7 @@ class HandlerLLM(HandlerBase, ABC):
         context = LLMContext(session_context.session_info.session_id)
         context.model_name = handler_config.model_name
         context.system_prompt = {'role': 'system', 'content': handler_config.system_prompt}
-        context.api_key = handler_config.api_key
+        context.api_key = self.resolve_api_key(handler_config)
         context.api_url = handler_config.api_url
         context.enable_video_input = handler_config.enable_video_input
         context.history = ChatHistory(history_length=handler_config.history_length)
@@ -222,4 +233,3 @@ class HandlerLLM(HandlerBase, ABC):
             except Exception:
                 pass
             context.client = None
-

--- a/tests/test_openai_compatible_llm_config.py
+++ b/tests/test_openai_compatible_llm_config.py
@@ -1,0 +1,154 @@
+import importlib
+import sys
+import types
+from enum import Enum
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel
+
+
+def install_module(name: str, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+class _Logger:
+    def __getattr__(self, _name):
+        return lambda *args, **kwargs: None
+
+
+class _HandlerBase:
+    def __init__(self):
+        pass
+
+
+class _HandlerBaseConfigModel(BaseModel):
+    pass
+
+
+class _HandlerContext:
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+
+
+class _HandlerBaseInfo(dict):
+    pass
+
+
+class _HandlerDataInfo(dict):
+    pass
+
+
+class _HandlerDetail(dict):
+    pass
+
+
+class _ChatDataType(Enum):
+    HUMAN_TEXT = "human_text"
+    CAMERA_VIDEO = "camera_video"
+    AVATAR_TEXT = "avatar_text"
+
+
+class _OpenAI:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class _APIStatusError(Exception):
+    body = None
+
+
+def install_llm_handler_stubs():
+    install_module("loguru", logger=_Logger())
+    install_module("openai", APIStatusError=_APIStatusError, OpenAI=_OpenAI)
+    install_module("chat_engine")
+    install_module("chat_engine.contexts")
+    install_module("chat_engine.contexts.handler_context", HandlerContext=_HandlerContext)
+    install_module("chat_engine.contexts.session_context", SessionContext=object)
+    install_module("chat_engine.common")
+    install_module("chat_engine.common.handler_base",
+                   HandlerBase=_HandlerBase,
+                   HandlerBaseInfo=_HandlerBaseInfo,
+                   HandlerDataInfo=_HandlerDataInfo,
+                   HandlerDetail=_HandlerDetail)
+    install_module("chat_engine.data_models")
+    install_module("chat_engine.data_models.chat_engine_config_data",
+                   ChatEngineConfigModel=object,
+                   HandlerBaseConfigModel=_HandlerBaseConfigModel)
+    install_module("chat_engine.data_models.chat_data")
+    install_module("chat_engine.data_models.chat_data.chat_data_model", ChatData=object)
+    install_module("chat_engine.data_models.chat_data_type", ChatDataType=_ChatDataType)
+    install_module("chat_engine.data_models.chat_signal",
+                   ChatSignal=object,
+                   SignalFilterRule=lambda *args, **kwargs: (args, kwargs))
+    install_module("chat_engine.data_models.chat_signal_type",
+                   ChatSignalType=types.SimpleNamespace(STREAM_CANCEL="stream_cancel"))
+    install_module("chat_engine.data_models.chat_stream", StreamKey=str)
+    install_module("chat_engine.data_models.chat_stream_config",
+                   ChatStreamConfig=lambda **kwargs: kwargs)
+    install_module("chat_engine.data_models.runtime_data")
+    install_module("chat_engine.data_models.runtime_data.data_bundle",
+                   DataBundle=object,
+                   DataBundleDefinition=type(
+                       "DataBundleDefinition",
+                       (),
+                       {"add_entry": lambda self, entry: None},
+                   ),
+                   DataBundleEntry=types.SimpleNamespace(
+                       create_text_entry=lambda name: name,
+                       create_audio_entry=lambda *args: args,
+                   ))
+    install_module("handlers.llm.openai_compatible.chat_history_manager",
+                   ChatHistory=lambda **kwargs: object(),
+                   HistoryMessage=lambda **kwargs: kwargs)
+
+
+def import_llm_handler():
+    install_llm_handler_stubs()
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+    sys.modules.pop(
+        "handlers.llm.openai_compatible.llm_handler_openai_compatible",
+        None,
+    )
+    return importlib.import_module(
+        "handlers.llm.openai_compatible.llm_handler_openai_compatible"
+    )
+
+
+def test_resolve_api_key_prefers_explicit_value(monkeypatch):
+    module = import_llm_handler()
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "env-key")
+
+    config = module.LLMConfig(api_key="explicit-key", api_key_env="ATLASCLOUD_API_KEY")
+
+    assert module.HandlerLLM.resolve_api_key(config) == "explicit-key"
+
+
+def test_resolve_api_key_reads_configured_environment_variable(monkeypatch):
+    module = import_llm_handler()
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "env-key")
+
+    config = module.LLMConfig(api_key_env="ATLASCLOUD_API_KEY")
+
+    assert module.HandlerLLM.resolve_api_key(config) == "env-key"
+
+
+def test_atlascloud_preset_uses_atlas_environment_variable():
+    config_path = (
+        Path(__file__).resolve().parents[1]
+        / "config"
+        / "chat_with_atlascloud_edge_tts.yaml"
+    )
+
+    config = yaml.safe_load(config_path.read_text())
+    llm_config = config["default"]["chat_engine"]["handler_configs"][
+        "LLMOpenAICompatible"
+    ]
+
+    assert llm_config["api_url"] == "https://api.atlascloud.ai/v1"
+    assert llm_config["api_key_env"] == "ATLASCLOUD_API_KEY"
+    assert llm_config["model_name"] == "qwen/qwen3.5-flash"


### PR DESCRIPTION
## Summary
- add `api_key_env` support to the OpenAI-compatible LLM handler while preserving the existing `DASHSCOPE_API_KEY` default
- add `config/chat_with_atlascloud_edge_tts.yaml` for Atlas Cloud LLM + existing Edge TTS + LiteAvatar setup
- document the new `api_key_env` option and include the Atlas Cloud preset in the preset tables

## Validation
- `python3 -m py_compile src/handlers/llm/openai_compatible/llm_handler_openai_compatible.py tests/test_openai_compatible_llm_config.py`
- `python3 -m pytest tests/test_openai_compatible_llm_config.py -q`
- parsed `config/chat_with_atlascloud_edge_tts.yaml` with PyYAML
- `git diff --check`
- confirmed Atlas Cloud live model catalog includes `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

No root README changes.
