### PR TITLE
fix: preserve startup errors and exit status

### DIFF
--- a/src/demo.py
+++ b/src/demo.py
@@ -98,12 +98,21 @@ def main():
     server.run()
 
 
-if __name__ == "__main__":
+def _run_main():
     try:
         main()
     except KeyboardInterrupt:
         logger.info("Received KeyboardInterrupt, exiting.")
+    except Exception:
+        logger.exception("OpenAvatarChat failed to start")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        exit_code = _run_main()
     finally:
         signal.signal(signal.SIGINT, signal.SIG_DFL)
         signal.signal(signal.SIGTERM, signal.SIG_DFL)
-        os._exit(0)
+    os._exit(exit_code)

--- a/tests/test_demo_entrypoint.py
+++ b/tests/test_demo_entrypoint.py
@@ -1,0 +1,75 @@
+import runpy
+import sys
+import types
+from pathlib import Path
+
+
+class RecordingLogger:
+    def __init__(self):
+        self.exception_messages = []
+
+    def exception(self, message):
+        self.exception_messages.append(message)
+
+    def info(self, _message):
+        pass
+
+
+def install_module(monkeypatch, name, **attributes):
+    module = types.ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def load_demo(monkeypatch):
+    class FakeChatEngine:
+        pass
+
+    class FakeServer:
+        pass
+
+    class FakeFastAPI:
+        pass
+
+    class FakeDirectoryInfo:
+        @staticmethod
+        def get_project_dir():
+            return "/tmp/open-avatar-chat"
+
+    logger = RecordingLogger()
+
+    install_module(monkeypatch, "chat_engine")
+    install_module(monkeypatch, "chat_engine.chat_engine", ChatEngine=FakeChatEngine)
+    install_module(monkeypatch, "gradio")
+    install_module(monkeypatch, "uvicorn", Server=FakeServer, Config=object)
+    install_module(monkeypatch, "fastapi", FastAPI=FakeFastAPI)
+    install_module(monkeypatch, "loguru", logger=logger)
+    install_module(monkeypatch, "engine_utils")
+    install_module(monkeypatch, "engine_utils.directory_info", DirectoryInfo=FakeDirectoryInfo)
+    install_module(monkeypatch, "service")
+    install_module(monkeypatch, "service.service_utils")
+    install_module(monkeypatch, "service.service_utils.logger_utils", config_loggers=lambda *_args: None)
+    install_module(monkeypatch, "service.service_utils.service_config_loader", load_configs=lambda *_args: None)
+    install_module(monkeypatch, "service.service_utils.ssl_helpers", create_ssl_context=lambda *_args: None)
+    install_module(monkeypatch, "torch", load=lambda *_args, **_kwargs: None)
+
+    demo_path = Path(__file__).parents[1] / "src" / "demo.py"
+    namespace = runpy.run_path(demo_path, run_name="demo_under_test")
+    return namespace, logger
+
+
+def test_run_main_logs_unhandled_startup_failure_and_returns_nonzero(monkeypatch):
+    namespace, logger = load_demo(monkeypatch)
+    run_main = namespace.get("_run_main")
+
+    assert callable(run_main), "demo.py must expose a testable entrypoint wrapper"
+
+    def fail_startup():
+        raise RuntimeError("startup failed")
+
+    run_main.__globals__["main"] = fail_startup
+
+    assert run_main() == 1
+    assert logger.exception_messages == ["OpenAvatarChat failed to start"]


### PR DESCRIPTION
## Summary

- log unhandled startup exceptions with their traceback
- preserve a nonzero process exit status when initialization fails
- retain the existing immediate-exit behavior used after shutdown
- add a regression test for startup failures

## Root cause

The top-level entrypoint currently calls `os._exit(0)` from an unconditional `finally` block. Any exception raised while loading handlers is therefore discarded before Python can report it, and Docker sees a successful exit even though the service never started.

This matches the symptom in #296: handler registration succeeds, loading stops partway through initialization, no traceback is shown, and the container exits as status 0. The reported log only proves that SenseVoice was registered; its model load had not started yet. The next handler after the last successful load message is Silero VAD.

This change keeps the explicit `os._exit` behavior but logs unexpected exceptions and propagates exit status 1, so the underlying handler error becomes actionable.

## Verification

- `python3 -m pytest -q tests/test_demo_entrypoint.py` (1 passed)
- `python3 -m py_compile src/demo.py tests/test_demo_entrypoint.py`
- `git diff --check`

Related to #296.